### PR TITLE
Update GetTableUsage_RestartProof_AllDatabases.sql

### DIFF
--- a/Diagnostics/GetTableUsage_RestartProof_AllDatabases.sql
+++ b/Diagnostics/GetTableUsage_RestartProof_AllDatabases.sql
@@ -90,7 +90,7 @@ BEGIN
 	WHILE @@FETCH_STATUS = 0  
 
 	BEGIN
-		SET @DynamicSQL += 
+		SET @DynamicSQL = 
 		N'
 		USE '+QUOTENAME(@CurrentDB)+N'; 
 


### PR DESCRIPTION
Hello,

I've find out that que SQL diagnostic query  "GetTableUsage_RestartProof_AllDatabases.sql" has an issue.
Every time it loops on the databases' cursor, the inner dynamic query is appended with the same template. Which make the query grow linearly and apply one more time for each database loop.

IE :
First loop : 1 pass on first
Second loop : 1 pass on first, 1 pass on second
....

Have a nice day